### PR TITLE
chore: update publish workflow to run only after successful CI on main ✅

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,20 @@
 name: Publish to NPM and GitHub Release
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
 
 permissions:
-   contents: write
-   packages: write
-   id-token: write
+  contents: write
+  packages: write
+  id-token: write
+  pull-requests: write
 
 jobs:
   release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -50,8 +53,6 @@ jobs:
 
           git add package*.json
           git commit -m "chore: bump version to $VERSION 🚀" || echo "No changes to commit"
-          git tag "$TAG" || echo "Tag $TAG already exists"
-          git push origin main --tags
 
       - name: Build project
         run: npm run build
@@ -72,14 +73,13 @@ jobs:
             echo "📋 Minor improvements and bug fixes." > RELEASE_NOTES.md
           fi
 
-      - name: Publish to NPM
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
         with:
-          tag_name: ${{ env.TAG }}
-          name: v${{ env.VERSION }}
-          body_path: RELEASE_NOTES.md
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: bump version to ${{ env.VERSION }} 🚀"
+          title: "chore: release v${{ env.VERSION }} 🚀"
+          body-path: RELEASE_NOTES.md
+          branch: release/v${{ env.VERSION }}
+          base: main
+          delete-branch: true


### PR DESCRIPTION
# 📋 Pull Request

## ✅ What’s Changed

- Summarize the changes made
- Mention related Issue numbers (if any)

## 🚀 Why This Is Needed

- Explain the motivation behind your change
- Why should this be merged?

## 🔍 Checklist

- [ ] I ran `npm run lint` and there are no linting errors
- [ ] I ran `npm run build` and there are no build errors
- [ ] I updated documentation (README, API docs) if needed
- [ ] I agree to follow the project's Code of Conduct

---

Thanks for your contribution! 🎉
